### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#xc-launch
+# xc-launch
 
 ```
       ____________________________
@@ -67,7 +67,7 @@ Personally I use the terrific [DTerm](http://decimus.net/dterm), with a shortcut
 
 Distributed under the [MIT](http://en.wikipedia.org/wiki/MIT_License) & [Anyone but Richard Stallman](https://github.com/landondyer/kasm/blob/master/LICENSE) licenses ;-)
 
-###MIT - Licence
+### MIT - Licence
 
 Copyright (c) 2013 Diego Freniche
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
